### PR TITLE
APIKIT-2051: Remove weave service dependency in order to avoid class …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
         <!-- Test -->
         <mule.http.connector.version>1.5.3</mule.http.connector.version>
         <mule.apikit.module.version>1.3.10-SNAPSHOT</mule.apikit.module.version>
-        <mule.service.weave.version>2.3.0-SNAPSHOT</mule.service.weave.version>
     </properties>
 
     <build>
@@ -175,12 +174,6 @@
             <artifactId>mule-http-connector</artifactId>
             <version>${mule.http.connector.version}</version>
             <classifier>mule-plugin</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.services</groupId>
-            <artifactId>mule-service-weave</artifactId>
-            <version>${mule.service.weave.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
…loading issues due to incorrect dependencies resolution when packaging the service