### PR TITLE
W-15347586 - Fix illegal access error while running on J17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Dfile.encoding=UTF-8 -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile='${session.executionRootDirectory}/target/jacoco.exec'</argLine>
+                    <argLine>-Dfile.encoding=UTF-8 -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile='${session.executionRootDirectory}/target/jacoco.exec'
+                             --add-exports java.base/sun.net.www.protocol.jar=ALL-UNNAMED
+                             --add-opens java.base/java.util=ALL-UNNAMED
+                             --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
                     <properties>
                         <property>
                             <name>listener</name>


### PR DESCRIPTION
Added the following runtime jvm arguments to fix illegal access error while running on java 17:
- --add-exports java.base/sun.net.www.protocol.jar=ALL-UNNAMED
- --add-opens java.base/java.util=ALL-UNNAMED
- --add-opens java.base/java.lang=ALL-UNNAMED

ERROR:
```
initializationError(org.mule.module.apikit.metadata.MetadataTestCase) Time elapsed: 0.006 s <<<
ERROR!java.lang.IllegalAccessError: superclass access check failed: class 
org.mule.runtime.module.artifact.api.classloader.FineGrainedControlClassLoader$NonCachingJarResourceURLStreamHandler 
(in unnamed module @0x25618e91) cannot access class sun.net.www.protocol.jar.Handler (in module java.base) because module java.base does not export sun.net.www.protocol.jar to unnamed module @0x25618e91
```